### PR TITLE
Potential fix for code scanning alert no. 11: Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/sourceforge/get_direct_links.py
+++ b/sourceforge/get_direct_links.py
@@ -20,9 +20,9 @@ def get_links(url):
     try:
         final = requests.get(url, allow_redirects=True, stream=True, timeout=10)
     except Exception:
-        return
+        return None
     if final.status_code != 200:
-        return
+        return None
     direct_links = []
     for mirror in mirror_list:
         regex = f"{mirror['short_name']}.dl"


### PR DESCRIPTION
Potential fix for [https://github.com/crazyuploader/Python/security/code-scanning/11](https://github.com/crazyuploader/Python/security/code-scanning/11)

To fix the issue, we will make all return paths in the `get_links` function explicit. Specifically:
1. Add an explicit `return None` in the `except` block on line 22 and after the `if final.status_code != 200` check on line 24.
2. This ensures that the function always explicitly returns a value (`direct_links` or `None`), making its behavior more predictable and easier to understand.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
